### PR TITLE
ときどき目標面積を超えた大きな図形が描写されるよぉ...の修正

### DIFF
--- a/外部変形/binaryEnv/Calc.py
+++ b/外部変形/binaryEnv/Calc.py
@@ -13,7 +13,7 @@ def line_cross_point(A, B, C, D, count, calc_count):
   x = A.x + AB.x*sn/d
   y = A.y + AB.y*sn/d
   P = Point(x,y)
-  if(A.distance(B) ==  (P.distance(A) + P.distance(B))):
+  if(A.x <= P.x <= B.x and A.y <= P.y <= B.y) or (A.x >= P.x >= B.x and A.y >= P.y >= B.y) or (A.x <= P.x <= B.x and A.y >= P.y >= B.y) or (A.x >= P.x >= B.x and A.y <= P.y <= B.y):
     return P
 
 # 渡されたframeの面積を計算する関数

--- a/外部変形/binaryEnv/Calc.py
+++ b/外部変形/binaryEnv/Calc.py
@@ -1,7 +1,7 @@
 from point import Point
 
 # 線分ABと直線CDの交点
-def line_cross_point(A, B, C, D):
+def line_cross_point(A, B, C, D, count, calc_count):
   AB = Point((B.x - A.x), (B.y - A.y))
   CD = Point((D.x - C.x), (D.y - C.y))
   d = AB.x*CD.y - CD.x*AB.y

--- a/外部変形/binaryEnv/binary_search.py
+++ b/外部変形/binaryEnv/binary_search.py
@@ -133,7 +133,7 @@ def binary_search(search_frame, search_range ,move_line, target_area):
   
   # 決定した点で取得できるFrame取得
   parcel_frame, remain_frame = get_tmp_parcel(search_frame, move_line,tmp_point)
-  print(f"2分探索酋長 計算回数:{calc_count} 回 面積:{parcel_frame.area} / 目標面積：{target_area}")
+  print(f"探索終了 計算回数:{calc_count}回 比率：{math.floor(int(parcel_frame.area) / int (target_area)*1000) / 1000}  面積:{math.floor(int(parcel_frame.area)/1000000*1000)/1000}㎡ / 目標面積：{int (target_area)/1000000}㎡")
   return parcel_frame, remain_frame
 
 

--- a/外部変形/binaryEnv/binary_search.py
+++ b/外部変形/binaryEnv/binary_search.py
@@ -4,7 +4,7 @@ from point import Point
 from frame import Frame
 import draw_dxf
 
-def get_side_parcel(search_frame,load_frame,target_area,move_line):
+def get_side_parcel(search_frame,load_frame,target_area,move_line,count):
   """端の区画割を行う関数
 
   Args:
@@ -29,7 +29,7 @@ def get_side_parcel(search_frame,load_frame,target_area,move_line):
   search_line_range = [min, max]
 
   # 一時的なポイント処理
-  parcel_frame, remain_frame = binary_search(search_frame, search_line_range ,move_line, target_area)  
+  parcel_frame, remain_frame = binary_search(search_frame, search_line_range ,move_line, target_area, count)  
   return parcel_frame,remain_frame
 
 # 探索軸の最大最小の取得
@@ -77,7 +77,7 @@ def get_search_range(search_frame, search_line):
 # 探索領域のArr
 # 奥行ベクトル
 # 目標面積
-def binary_search(search_frame, search_range ,move_line, target_area):
+def binary_search(search_frame, search_range ,move_line, target_area,count):
   """二分探索を行う関数
 
   Args:
@@ -104,15 +104,15 @@ def binary_search(search_frame, search_range ,move_line, target_area):
   while (first_min.distance(min) < first_min.distance(max)):
     # 中央値取得
     tmp_point = Point.get_middle_point(max,min)
-    tmp_frame = get_tmp_parcel(search_frame, move_line, tmp_point)[0]
+    tmp_frame = get_tmp_parcel(search_frame, move_line, tmp_point,count,calc_count)[0]
     
     # プラス側
     tmp_inc_point = tmp_point.add(inc_point)
-    tmp_inc_frame = get_tmp_parcel(search_frame, move_line, tmp_inc_point)[0]
+    tmp_inc_frame = get_tmp_parcel(search_frame, move_line, tmp_inc_point,count,calc_count)[0]
     
     # マイナス側
     tmp_dec_point = tmp_point.add(dec_point)
-    tmp_dec_frame = get_tmp_parcel(search_frame, move_line, tmp_dec_point)[0]
+    tmp_dec_frame = get_tmp_parcel(search_frame, move_line, tmp_dec_point,count,calc_count)[0]
     
     # それぞれの目標値との差分を取得
     tmp_point_diff = math.fabs(target_area - tmp_frame.area)
@@ -132,13 +132,13 @@ def binary_search(search_frame, search_range ,move_line, target_area):
       break
   
   # 決定した点で取得できるFrame取得
-  parcel_frame, remain_frame = get_tmp_parcel(search_frame, move_line,tmp_point)
+  parcel_frame, remain_frame = get_tmp_parcel(search_frame, move_line,tmp_point, count,calc_count)
   print(f"探索終了 計算回数:{calc_count}回 比率：{math.floor(int(parcel_frame.area) / int (target_area)*1000) / 1000}  面積:{math.floor(int(parcel_frame.area)/1000000*1000)/1000}㎡ / 目標面積：{int (target_area)/1000000}㎡")
   return parcel_frame, remain_frame
 
 
 # 判定軸上指定した点から，奥行ベクトルを伸ばし，一時的な区画を取得する
-def get_tmp_parcel(search_frame, move_line, point):
+def get_tmp_parcel(search_frame, move_line, point, count, calc_count):
   """判定軸上指定した点から，奥行ベクトルを伸ばし，一時的な区画を取得する
 
   Args:
@@ -150,7 +150,7 @@ def get_tmp_parcel(search_frame, move_line, point):
     parcel_frame (Frame): _作成した図形の集合
     remain_frame (Frame): _作成した図形の集合
   """
-  parcel_frame, remain_frame = Frame.get_tmp_frame(search_frame, point, move_line)
+  parcel_frame, remain_frame = Frame.get_tmp_frame(search_frame, point, move_line, count, calc_count)
   
   return parcel_frame, remain_frame
 

--- a/外部変形/binaryEnv/binary_split_main.py
+++ b/外部変形/binaryEnv/binary_split_main.py
@@ -109,7 +109,7 @@ def main():
   # 探索領域が目標面積取れなくなるまで区画割
   while(True):
     print(f"\n{count} 回目")
-    parcel_frame, remain_frame = binary_search.get_side_parcel(search_frame,load_frame[0],target_area,move_line)
+    parcel_frame, remain_frame = binary_search.get_side_parcel(search_frame,load_frame[0],target_area,move_line,count)
     
     count += 1
     binary_parcel_list.append(parcel_frame)

--- a/外部変形/binaryEnv/frame.py
+++ b/外部変形/binaryEnv/frame.py
@@ -1,6 +1,7 @@
 import numpy as np
 from point import Point
 import Calc
+import draw_dxf
 
 class Frame:
     """区画を扱うクラス
@@ -18,7 +19,8 @@ class Frame:
       self.area = Calc.calc_area(self)
 
     # 直線ABで区切られる区画を返す
-    def get_tmp_frame(self, point_A, point_B):
+    def get_tmp_frame(self, point_A, point_B, count,calc_count):
+    # def get_tmp_frame(self, point_A, point_B):
       """探索領域を直線ABで区切り,区画と残りの探索領域を取得する
 
       Args:
@@ -38,7 +40,7 @@ class Frame:
       for i in range(len(self.points)):
         point_s = self.points[i]
         point_e = self.points[i + 1] if(i+1<len(self.points)) else self.points[0]
-        line_cross = Calc.line_cross_point(point_s, point_e, point_A, point_B)
+        line_cross = Calc.line_cross_point(point_s, point_e, point_A, point_B, count,calc_count)
         
         if(get_frame_flag):
           parcel_points.append(point_s)
@@ -86,12 +88,3 @@ class Frame:
       
       move_positive_point = Point(min_x, min_y) 
       self = self.move_frame(move_positive_point)
-
-# search_frame = [
-#   Point(0,0),
-#   Point(300,0),
-#   Point(500,100),
-#   Point(100,100),
-# ]
-# search_frame = Frame(search_frame)
-# print(search_frame.area)

--- a/外部変形/binaryEnv/frame.py
+++ b/外部変形/binaryEnv/frame.py
@@ -60,6 +60,12 @@ class Frame:
         self.points[i] = self.points[i].add(point)
       return self
 
+    def debug_move_frame(self, point):
+      debug_points = []
+      for i in range(len(self.points)):
+        debug_points.append(self.points[i].add(point))
+      return Frame(debug_points)
+
     def get_points_str(self):
       str = ""
       for i in range(len(self.points)):

--- a/外部変形/binaryEnv/point.py
+++ b/外部変形/binaryEnv/point.py
@@ -56,7 +56,7 @@ class Point:
         return array
     
     def get_str(self):
-        return f"({self.x}, {self.y})"
+        return f"({int(self.x)}, {int(self.y)})"
     
     # ABの内席取得
     def dot(A,B):


### PR DESCRIPTION

原因
line_cross判定の線分上判定で細かな誤差を許容していなかった．

修正として，線分上判定を座標の範囲かどうかで判定したよ

![image](https://github.com/FUJI-CORPORATION-GROUP/parcel_allocation/assets/120772851/8a4dd674-2a13-4279-a5f5-a07c8c763382)
