### PR TITLE
目標面積を範囲内でランダムに決定

### DIFF
--- a/外部変形/binaryEnv/binary_split_main.py
+++ b/外部変形/binaryEnv/binary_split_main.py
@@ -1,3 +1,5 @@
+import math
+import random
 from point import Point
 from frame import Frame
 import binary_search
@@ -103,12 +105,13 @@ def main():
   binary_parcel_list = []
   count = 0
   # target_area = 1000
-
-  # print(f"search_frame : {search_frame.get_points_str()}")
+  target_min_area = 90000000
+  target_max_area = 110000000
 
   # 探索領域が目標面積取れなくなるまで区画割
   while(True):
-    print(f"\n{count} 回目")
+    target_area = random.randint(target_min_area,target_max_area)
+    print(f"\n{count} 回目 探索開始 目標面積：{target_area}")
     parcel_frame, remain_frame = binary_search.get_side_parcel(search_frame,load_frame[0],target_area,move_line,count)
     
     
@@ -116,7 +119,7 @@ def main():
     binary_parcel_list.append(parcel_frame)
     
     if(target_area > remain_frame.area):
-      print(f"探索終了 残り面積{remain_frame.area}")
+      print(f"探索終了 残り面積{math.floor(remain_frame.area/1000000)}㎡")
       break
     
     if(count > 30):


### PR DESCRIPTION
目標面積入力機構がないので，モックとして宣言したやつの範囲で乱数でtarget_areaを決定した．

<img width="538" alt="image" src="https://github.com/FUJI-CORPORATION-GROUP/parcel_allocation/assets/120772851/8807492e-2630-4a85-8943-1660fa16a355">

```
0 回目 探索開始 目標面積：91404624
探索終了 計算回数:15回 比率：1.0  面積:91.411㎡ / 目標面積：91.404624㎡

1 回目 探索開始 目標面積：97599994
探索終了 計算回数:17回 比率：1.0  面積:97.604㎡ / 目標面積：97.599994㎡

...

23 回目 探索開始 目標面積：103910388
探索終了 計算回数:12回 比率：0.999  面積:103.907㎡ / 目標面積：103.910388㎡

24 回目 探索開始 目標面積：96874899
探索終了 計算回数:13回 比率：0.999  面積:96.864㎡ / 目標面積：96.874899㎡
探索終了 残り面積93㎡
```