### PR TITLE
区画割が逆になるとかの修正

### DIFF
--- a/外部変形/binaryEnv/binary_calc.py
+++ b/外部変形/binaryEnv/binary_calc.py
@@ -43,3 +43,23 @@ def calc_area(frame):
   for i in range(len(frame)):
       area += (frame[i].x * frame[0].y - frame[i].y * frame[0].x) / 2 if i == len(frame) - 1 else (frame[i].x * frame[i + 1].y - frame[i].y * frame[i + 1].x) / 2
   return abs(area)
+
+# 直線AB上の点Pから垂直に落とした点Hを求める
+def Get_vertical_intersection(A, B, P):
+    """直線AB上の点Pから垂直に落とした点を求める
+
+    Args:
+    A (Point): _探索軸の始点
+    B (Point): _探索軸の終点
+    P (Point): _AとBの二点のリスト
+
+    Returns:
+    point_on_judge_line (Point): _判定軸上の点
+    """
+    AB = Point(B.x - A.x, B.y - A.y)
+    AP = Point(P.x - A.x, P.y - A.y)
+
+    k = Point.dot(AB, AP) / (AB.magnitude() ** 2)
+    OH = Point(k * AB.x, k * AB.y)
+    point_on_judge_line =  Point(OH.x + A.x, OH.y + A.y)
+    return point_on_judge_line

--- a/外部変形/binaryEnv/binary_search.py
+++ b/外部変形/binaryEnv/binary_search.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 from point import Point
 from frame import Frame
+import binary_calc as Calc
 import draw_dxf
 
 def get_side_parcel(search_frame,load_frame,target_area,move_line,count):
@@ -26,7 +27,7 @@ def get_side_parcel(search_frame,load_frame,target_area,move_line,count):
   search_line = [search_line_start_point,search_line_end_point]
 
   # 探索範囲の取得
-  max, min = get_search_range(search_frame,search_line)
+  max, min = get_search_range(search_frame,search_line,count)
   search_line_range = [min, max]
 
   # 一時的なポイント処理
@@ -34,7 +35,7 @@ def get_side_parcel(search_frame,load_frame,target_area,move_line,count):
   return parcel_frame,remain_frame
 
 # 探索軸の最大最小の取得
-def get_search_range(search_frame, search_line):
+def get_search_range(search_frame, search_line, count):
   """探索軸の最大最小の取得
 
   Args:
@@ -117,15 +118,15 @@ def binary_search(search_frame, search_range ,move_line, target_area,count):
   while (first_min.distance(min) < first_min.distance(max)):
     # 中央値取得
     tmp_point = Point.get_middle_point(max,min)
-    tmp_frame = Frame.get_tmp_frame(search_frame, move_line, tmp_point,first_min,count,calc_count)[0]
+    tmp_frame = Frame.get_tmp_frame(search_frame, move_line, tmp_point,first_min,first_max,count,calc_count)[0]
 
     # プラス側
     tmp_inc_point = tmp_point.add(inc_point)
-    tmp_inc_frame = Frame.get_tmp_frame(search_frame, move_line, tmp_inc_point,first_min,count,calc_count)[0]
+    tmp_inc_frame = Frame.get_tmp_frame(search_frame, move_line, tmp_inc_point,first_min,first_max,count,calc_count)[0]
 
     # マイナス側
     tmp_dec_point = tmp_point.add(dec_point)
-    tmp_dec_frame = Frame.get_tmp_frame(search_frame, move_line, tmp_dec_point,first_min,count,calc_count)[0]
+    tmp_dec_frame  = Frame.get_tmp_frame(search_frame, move_line, tmp_dec_point,first_min,first_max,count,calc_count)[0]
 
     # それぞれの目標値との差分を取得
     tmp_point_diff = math.fabs(target_area - tmp_frame.area)
@@ -145,31 +146,10 @@ def binary_search(search_frame, search_range ,move_line, target_area,count):
       break
   
   # 決定した点で取得できるFrame取得
-  parcel_frame, remain_frame = Frame.get_tmp_frame(search_frame, move_line,tmp_point, first_min,count,calc_count)
+  parcel_frame, remain_frame = Frame.get_tmp_frame(search_frame, move_line,tmp_point, first_min,first_max,count,calc_count)
   
   print(f"探索終了 計算回数:{calc_count}回 比率：{math.floor(int(parcel_frame.area) / int (target_area)*1000) / 1000}  面積:{math.floor(int(parcel_frame.area)/1000000*1000)/1000}㎡ / 目標面積：{int (target_area)/1000000}㎡")
   return parcel_frame, remain_frame
-
-# 直線AB上の点Pから垂直に落とした点Hを求める
-def Get_vertical_intersection(A, B, P):
-  """直線AB上の点Pから垂直に落とした点を求める
-
-  Args:
-    A (Point): _探索軸の始点
-    B (Point): _探索軸の終点
-    P (Point): _AとBの二点のリスト
-
-  Returns:
-    point_on_judge_line (Point): _判定軸上の点
-  """
-  AB = Point(B.x - A.x, B.y - A.y)
-  AP = Point(P.x - A.x, P.y - A.y)
-
-  k = Point.dot(AB, AP) / (AB.magnitude() ** 2)
-  OH = Point(k * AB.x, k * AB.y)
-  point_on_judge_line =  Point(OH.x + A.x, OH.y + A.y)
-  return point_on_judge_line
-
 
 
 # デバッグ用メイン関数

--- a/外部変形/binaryEnv/binary_search.py
+++ b/外部変形/binaryEnv/binary_search.py
@@ -51,25 +51,36 @@ def get_search_range(search_frame, search_line):
   # TODO: minとmaxの初期化
   max, min = search_line_start_point, search_line_end_point
 
+  point_list_on_line = []
+
   # 判定軸上の座標取得
   for i in range(len(search_frame)):
-    point = Get_vertical_intersection(search_line_start_point,search_line_end_point,search_frame[i])
+    point = Calc.Get_vertical_intersection(search_line_start_point,search_line_end_point,search_frame[i])
+    point_list_on_line.append(point)
 
-    default_distance = max.distance(min)
+  distance_max_A = 0
+  for i in range(len(point_list_on_line)):
+    distance = point_list_on_line[i].distance(point_list_on_line[0])
+    if(distance > distance_max_A):
+      distance_max_A = distance
+      point_A = point_list_on_line[i]
 
-    if (i == 0):
-      max = point
-      min = point
-      continue
+  distance_max_B = 0
+  for i in range(len(point_list_on_line)):
+    distance = point_list_on_line[i].distance(point_A)
+    if(distance > distance_max_B):
+      distance_max_B = distance
+      point_B = point_list_on_line[i]
+  
+  search_line_vec = Point.sub(search_line_end_point,search_line_start_point)
+  edge_line_AB_vec = Point.sub(point_B,point_A)
 
-    max_distance = max.distance(point)
-    min_distance = min.distance(point)
-
-    if(default_distance != max_distance + min_distance):
-      if(max_distance > min_distance):
-        min = point
-      else:
-        max = point
+  if(search_line_vec.dot(edge_line_AB_vec) < 0):
+    max = point_A
+    min = point_B
+  else:
+    max = point_B
+    min = point_A
 
   return max, min
 

--- a/外部変形/binaryEnv/frame.py
+++ b/外部変形/binaryEnv/frame.py
@@ -1,6 +1,6 @@
 import numpy as np
 from point import Point
-import Calc
+import binary_calc as Calc
 import draw_dxf
 
 class Frame:
@@ -19,7 +19,7 @@ class Frame:
       self.area = Calc.calc_area(self)
 
     # 直線ABで区切られる区画を返す
-    def get_tmp_frame(self, move_line_point, binary_point, min_point, count,calc_count):
+    def get_tmp_frame(self, move_line_point, binary_point, min_point,max_point, count,calc_count):
       """探索領域を直線ABで区切り,区画と残りの探索領域を取得する
 
       Args:
@@ -65,13 +65,13 @@ class Frame:
         parcel_frame = tmp_frame_B
         remain_frame = tmp_frame_A
       else:
-        tmp_barycenter_A = tmp_frame_A.get_barycenter()
-        tmp_barycenter_B = tmp_frame_B.get_barycenter()
+        tmp_barycenter_A = Calc.Get_vertical_intersection(min_point,max_point,tmp_frame_A.get_barycenter())
+        tmp_barycenter_B = Calc.Get_vertical_intersection(min_point,max_point,tmp_frame_B.get_barycenter())
         tmp_distance_A_min = tmp_barycenter_A.distance(min_point)
         tmp_distance_B_min = tmp_barycenter_B.distance(min_point)
         parcel_frame = tmp_frame_A if(tmp_distance_A_min < tmp_distance_B_min) else tmp_frame_B
         remain_frame = tmp_frame_B if(tmp_distance_A_min < tmp_distance_B_min) else tmp_frame_A
-      
+
       return parcel_frame, remain_frame
     
     def move_frame(self, point):


### PR DESCRIPTION
## やったこと
### 判定軸の取得方法の修正
従来
- 道路のstart,endを初期値のmin,maxとする
- 探索領域の座標から道路直線に垂直に落とした点Ｐを取得してmin,maxと距離で比較して更新
-> 点Ｐが外にある場合にうまくいってなかった

今回
- 探索領域の座標から道路直線に垂直に落とした点を全部取得する
- 一直線上の0番目の点からの距離が一番遠い点をＡとする
- Ａから一番遠い点をＢとする
- ＡとＢがどちらをmin,maxにするかを，道路の方向ベクトルとの内積で判定する

### 瓶の底を取るロジックの修正
従来
- 直線で区切られる2つの領域Ａ，Ｂを取得する
- Ａの重心と探索軸のminとの距離，Ｂの重心と探索軸のminとの距離を比較して，近いほうが瓶の底
-> 重心だと近いほうが瓶の底とは限らない

### その他リファクタ
- Calc -> binary_calc
 - 統合するときの変更を少なくするためにImportはCalcという変数で書いている
- Get_vertical_intersection()：垂直に下した点を取得する処理 -> binary_calcに移籍
 - 他でもいろいろ使いそうなので抜き出した

今回
- 直線で区切られる2つの領域Ａ，Ｂを取得する
- **Ａの重心を探索軸に垂直に下した点**と探索軸のminとの距離，**Ｂの重心を探索軸に垂直に下した点**と探索軸のminとの距離を比較して，近いほうが瓶の底
-> 同じ直線状に落として比較するよ


### 関連Issue
#45 
#37 

## 実行DXF
|before|after|
|:-:|:-:|
|<img width="800" alt="image" src="https://github.com/FUJI-CORPORATION-GROUP/parcel_allocation/assets/120772851/d7e75a49-ef0b-4d4e-86b7-130cdde8143c">|<img width="800" alt="image" src="https://github.com/FUJI-CORPORATION-GROUP/parcel_allocation/assets/120772851/3bc8f755-c9bd-4878-b801-fefaffe78c0b">|